### PR TITLE
Create optional packages to handle identities

### DIFF
--- a/Import/imports.mf
+++ b/Import/imports.mf
@@ -1,3 +1,11 @@
 <imports>
+  <package name="bpl.app.uploadMppImages.mppOptions" path="mppOptions\Import">
+    <dependson name="bpl.app.uploadMppImages" />
+    <dependson name="com.aras.innovator.solution.MPP-Application" />
+  </package>
   <package name="bpl.app.uploadMppImages" path="uploadMppImages\Import" />
+  <package name="bpl.app.uploadMppImages.techDocOptions" path="techDocOptions\Import">
+    <dependson name="bpl.app.uploadMppImages" />
+    <dependson name="com.aras.innovator.solution.TechDoc" />
+  </package>
 </imports>

--- a/Import/mppOptions/Import/Member/mpp-membership.xml
+++ b/Import/mppOptions/Import/Member/mpp-membership.xml
@@ -1,0 +1,7 @@
+<AML>
+  <Item type="Member" id="812B029D4950454FB53AAA4F30336CD9" action="add">
+    <related_id keyed_name="Manufacturing Engineering" type="Identity">D46B8ECBDB0C4D94BFF7A93D36FAB474</related_id>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="BPL_Image Uploaders" type="Identity">FA3CDC30103843498152D19507690F59</source_id>
+  </Item>
+</AML>

--- a/Import/mppOptions/Import/TOC Access/mpp-toc-access.xml
+++ b/Import/mppOptions/Import/TOC Access/mpp-toc-access.xml
@@ -1,0 +1,8 @@
+﻿<AML>
+ <Item type="TOC Access" id="2A528D60A89741EC8D07E48953468BB8" action="add">
+  <related_id keyed_name="BPL_Image Uploaders" type="Identity">FA3CDC30103843498152D19507690F59</related_id>
+  <sort_order>256</sort_order>
+  <source_id keyed_name="BPL_tp_Image_Uploader" type="ItemType" name="BPL_tp_Image_Uploader">B30D78F065C3486B8B27763805238DAA</source_id>
+  <category>Process</category>
+ </Item>
+</AML>

--- a/Import/techDocOptions/Import/Member/tech-doc-author-membership.xml
+++ b/Import/techDocOptions/Import/Member/tech-doc-author-membership.xml
@@ -1,0 +1,7 @@
+<AML>
+  <Item type="Member" id="344BFE7217B54342992175DBD9537F86" action="add">
+    <related_id keyed_name="Technical Document Author" type="Identity">6E4010637C1941748089C622D9C259F2</related_id>
+    <sort_order>256</sort_order>
+    <source_id keyed_name="BPL_Image Uploaders" type="Identity">FA3CDC30103843498152D19507690F59</source_id>
+  </Item>
+</AML>

--- a/Import/techDocOptions/Import/TOC Access/techdoc-toc-access.xml
+++ b/Import/techDocOptions/Import/TOC Access/techdoc-toc-access.xml
@@ -1,0 +1,8 @@
+﻿<AML>
+ <Item type="TOC Access" id="17B7801F91024D69ABF350F3A8267D36" action="add">
+  <related_id keyed_name="BPL_Image Uploaders" type="Identity">FA3CDC30103843498152D19507690F59</related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="BPL_tp_Image_Uploader" type="ItemType" name="BPL_tp_Image_Uploader">B30D78F065C3486B8B27763805238DAA</source_id>
+  <category>Technical Documentation</category>
+ </Item>
+</AML>

--- a/Import/uploadMppImages/Import/Identity/Image Uploaders.xml
+++ b/Import/uploadMppImages/Import/Identity/Image Uploaders.xml
@@ -1,0 +1,7 @@
+﻿<AML>
+ <Item type="Identity" id="FA3CDC30103843498152D19507690F59" action="add">
+  <description>Add identities to this group to grant TOC access/permissions</description>
+  <is_alias>0</is_alias>
+  <name>BPL_Image Uploaders</name>
+ </Item>
+</AML>

--- a/Import/uploadMppImages/Import/ItemType/BPL_tp_Image_Uploader.xml
+++ b/Import/uploadMppImages/Import/ItemType/BPL_tp_Image_Uploader.xml
@@ -69,15 +69,15 @@
     <source_id keyed_name="BPL_tp_Image_Uploader" type="ItemType" name="BPL_tp_Image_Uploader">B30D78F065C3486B8B27763805238DAA</source_id>
     <type>default</type>
    </Item>
-   <Item type="TOC Access" id="F61D7A10880D4322AB6DB742480773E2" action="add">
-    <related_id keyed_name="Manufacturing Engineering" type="Identity">D46B8ECBDB0C4D94BFF7A93D36FAB474</related_id>
+   <Item type="Can Add" id="0976F7DF54364C5E8B8F57215413B418" action="add">
+    <can_add>1</can_add>
+    <related_id keyed_name="BPL_Image Uploaders" type="Identity">FA3CDC30103843498152D19507690F59</related_id>
     <sort_order>128</sort_order>
     <source_id keyed_name="BPL_tp_Image_Uploader" type="ItemType" name="BPL_tp_Image_Uploader">B30D78F065C3486B8B27763805238DAA</source_id>
-    <category>Process</category>
    </Item>
    <Item type="Can Add" id="DA5D9B78CA0549BAAEFC54CF53FD7AAE" action="add">
     <can_add>1</can_add>
-    <related_id keyed_name="Manufacturing Engineering" type="Identity">D46B8ECBDB0C4D94BFF7A93D36FAB474</related_id>
+    <related_id keyed_name="BPL_Image Uploaders" type="Identity">FA3CDC30103843498152D19507690F59</related_id>
     <sort_order>128</sort_order>
     <source_id keyed_name="BPL_tp_Image_Uploader" type="ItemType" name="BPL_tp_Image_Uploader">B30D78F065C3486B8B27763805238DAA</source_id>
    </Item>

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ Internet Explorer 11, Chrome 61.0, Firefox ESR 52.4.0
 #### Important!
 **Always back up your code tree and database before applying an import package or code tree patch!**
 
-### Pre-requisites
+### Prerequisites
 
 1. Aras Innovator installed (version 11.0 SPx preferred)
 2. Aras Package Import tool
 3. Import package of this project
+4. MPP and/or Tech Docs must be installed in the target database
 
 ### Install Steps
 
@@ -43,16 +44,18 @@ Internet Explorer 11, Chrome 61.0, Firefox ESR 52.4.0
     * Optional: Enter a description in the Description field.
 5. Enter the path to your local `..\uploadMppImages\Import\imports.mf` file in the Manifest File field.
 6. Select **bpl.app.uploadMppImages** in the Available for Import field.
-7. Select Type = **Merge** and Mode = **Thorough Mode**.
-8. Click **Import** in the top left corner.
-9. Close the Aras Package Import tool.
+7. If the target database has the Technical Documentation application installed, select the **bpl.app.uploadMppImages.techDocOptions** package.
+8. If the target database has the MPP application installed, select the **bpl.app.uploadMppImages.mppOptions** package.
+9. Select Type = **Merge** and Mode = **Thorough Mode**.
+10. Click **Import** in the top left corner.
+11. Close the Aras Package Import tool.
 
 You are now ready to login to Aras and try out the image importer.
 
 ## Usage
 
 1. Login to Aras.
-2. Make sure, that you are a member of the Identity **Manufacturing Engineering**
+2. Make sure, that you are a member of the Identity **Manufacturing Engineering** or **Technical Documentation Author**.
 3  Navigate to **Process > Upload Image** in the table of contents (TOC).
 4. Right click on **Upload Image** and click **New Upload Images** 
 ![aras-image-uploader-for-tech-docs](./Screenshots/1_StartUploader.png)


### PR DESCRIPTION
### Fixes/changes:
<!-- Describe the modifications included in this pull request. -->
This pull request adds an identity called *BPL_Image Uploaders* to use for TOC Access and Can Get access. It also adds two optional packages to set TOC access and *BPL_Image Uploaders* membership based on the applications installed in the target database - one for MPP and one for Tech Docs.

### Reason:
<!-- If you are submitting a fix for an Issue, reference the issue by number to link it. For example, you can link Issue 5 by entering #5. -->
This pull request resolves Issue #4. If the primary import package references the Manufacturing Engineering identity and MPP is not installed in the target database, then an import error will occur. This prevents users from applying this solution to a database that has Tech Docs but not MPP installed.

### Testing:
<!-- What version(s) of Aras did you use to test these changes? Which browser(s)? -->
I only tested the changes using IE 11 because the changes to the packages are not browser-dependent.

#### Key:
Success: (:heavy_check_mark:) 
Issue: (:heavy_exclamation_mark:) 
Not Tested: (:heavy_minus_sign:)

<!-- Use symbols indicate success/issue/not tested. Example row: -->
<!-- 11 SP9 | :heavy_check_mark: | :heavy_check_mark: | :heavy_exclamation_mark: | :heavy_minus_sign: -->

#### Result:
Aras | IE 11 | Firefox ESR | Chrome | Edge 
-----|-------|----------------|--------|------
11 SPx |:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign: